### PR TITLE
👷 build(emojis): force emoji presentation

### DIFF
--- a/emojis/index.js
+++ b/emojis/index.js
@@ -1,14 +1,17 @@
-const emojiMap = new Map([
+// emoji code points
+// keys: presentation is default (may be text)
+// values: presentation is emoji
+const emojiPresentationMap = new Map([
   ["👷", "\ud83d\udc77"],
   ["💚", "\ud83d\udc9a"],
   ["📝", "\ud83d\udcdd"],
   ["✨", "\u2728"],
   ["🐛", "\ud83d\udc1b"],
-  ["⚡️", "\u26A1"],
-  ["♻️", "\u267b"],
+  ["⚡", "\u26A1"],
+  ["♻", "\u267b\ufe0f"], // Force Emoji Presentation, see https://www.unicode.org/emoji/charts-13.1/text-style.html, row "2002 ⊖ Dings"
   ["⏪", "\u23ea"],
   ["🎨", "\ud83c\udfa8"],
   ["✅", "\u2705"],
 ]);
 
-module.exports = emojiMap;
+module.exports = emojiPresentationMap;


### PR DESCRIPTION
♻ is presented as text by default: Added \ufe0f to its presentation
value.
Keys "♻" and "⚡" used to contain \ufe0f, now removed.
Renamed Map and added a comment to make more clear what it contains.