### PR TITLE
Fix conventional-changelog-organon

### DIFF
--- a/misc/emoji-presentation-map/package.json
+++ b/misc/emoji-presentation-map/package.json
@@ -14,10 +14,8 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!lib/**/*.map",
     "!lib/**/__tests__",
     "cjs",
-    "!cjs/**/*.map",
     "!cjs/**/__tests__"
   ],
   "author": {

--- a/misc/emoji-regex-rgi/package.json
+++ b/misc/emoji-regex-rgi/package.json
@@ -13,9 +13,7 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!lib/**/*.map",
-    "cjs",
-    "!cjs/**/*.map"
+    "cjs"
   ],
   "author": {
     "name": "Jason Lenoble",

--- a/rigs/organon-node-rig/profiles/commonjs-only/.eslintrc.js
+++ b/rigs/organon-node-rig/profiles/commonjs-only/.eslintrc.js
@@ -1,0 +1,6 @@
+// This is a workaround for https://github.com/eslint/eslint/issues/3458
+require("@rushstack/eslint-config/patch/modern-module-resolution");
+
+module.exports = {
+  extends: ["@rushstack/eslint-config/profile/node"],
+};

--- a/rigs/organon-node-rig/profiles/commonjs-only/config/typescript.json
+++ b/rigs/organon-node-rig/profiles/commonjs-only/config/typescript.json
@@ -1,0 +1,75 @@
+/**
+ * Configures the TypeScript plugin for Heft.  This plugin also manages linting.
+ */
+{
+  "$schema": "https://developer.microsoft.com/en-US/json-schemas/heft/typescript.schema.json",
+  /**
+   * Optionally specifies another JSON config file that this file extends from. This provides a way for standard
+   * settings to be shared across multiple projects.
+   */
+  // "extends": "base-project/config/typescript.json",
+  /**
+   * Can be set to "copy" or "hardlink". If set to "copy", copy files from cache.
+   * If set to "hardlink", files will be hardlinked to the cache location.
+   * This option is useful when producing a tarball of build output as TAR files don't
+   * handle these hardlinks correctly. "hardlink" is the default behavior.
+   */
+  // "copyFromCacheMode": "copy",
+  /**
+   * If provided, emit these module kinds in addition to the modules specified in the tsconfig.
+   * Note that this option only applies to the main tsconfig.json configuration.
+   */
+  "additionalModuleKindsToEmit": [
+    // {
+    //   /**
+    //    * (Required) Must be one of "commonjs", "amd", "umd", "system", "es2015", "esnext"
+    //    */
+    //   "moduleKind": "commonjs",
+    //   /**
+    //    * (Required) The name of the folder where the output will be written.
+    //    */
+    //   "outFolderName": "cjs"
+    // }
+  ],
+  /**
+   * Specifies the intermediary folder that tests will use.  Because Jest uses the
+   * Node.js runtime to execute tests, the module format must be CommonJS.
+   *
+   * The default value is "lib".
+   */
+  // "emitFolderNameForTests": "lib-commonjs",
+  /**
+   * If set to "true", the TSlint task will not be invoked.
+   */
+  // "disableTslint": true,
+  /**
+   * Set this to change the maximum number of file handles that will be opened concurrently for writing.
+   * The default is 50.
+   */
+  // "maxWriteParallelism": 50,
+  /**
+   * Configures additional file types that should be copied into the TypeScript compiler's emit folders, for example
+   * so that these files can be resolved by import statements.
+   */
+  "staticAssetsToCopy": {
+    /**
+     * File extensions that should be copied from the src folder to the destination folder(s).
+     */
+    // "fileExtensions": [
+    //   ".json", ".css"
+    // ],
+    /**
+     * Glob patterns that should be explicitly included.
+     */
+    // "includeGlobs": [
+    //   "some/path/*.js"
+    // ],
+    /**
+     * Glob patterns that should be explicitly excluded. This takes precedence over globs listed
+     * in "includeGlobs" and files that match the file extensions provided in "fileExtensions".
+     */
+    // "excludeGlobs": [
+    //   "some/path/*.css"
+    // ]
+  }
+}

--- a/rigs/organon-node-rig/profiles/commonjs-only/tsconfig-base.json
+++ b/rigs/organon-node-rig/profiles/commonjs-only/tsconfig-base.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "../../../../../lib",
+    "types": ["heft-jest"]
+  },
+  "include": ["../../../../../src"]
+}

--- a/rigs/organon-node-rig/profiles/commonjs-only/tsconfig-no-test.json
+++ b/rigs/organon-node-rig/profiles/commonjs-only/tsconfig-no-test.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig-base.json",
+  "compilerOptions": {
+    "types": []
+  }
+}

--- a/tooling/commitlint-config/package.json
+++ b/tooling/commitlint-config/package.json
@@ -13,9 +13,9 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!lib/**/*.map",
+    "!lib/**/__tests__",
     "cjs",
-    "!cjs/**/*.map"
+    "!cjs/**/__tests__"
   ],
   "author": {
     "name": "Jason Lenoble",

--- a/tooling/conventional-changelog/config/jest.config.json
+++ b/tooling/conventional-changelog/config/jest.config.json
@@ -1,3 +1,3 @@
 {
-  "testMatch": ["<rootDir>/cjs/**/*.test.js"]
+  "testMatch": ["<rootDir>/lib/**/*.test.js"]
 }

--- a/tooling/conventional-changelog/config/rig.json
+++ b/tooling/conventional-changelog/config/rig.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://developer.microsoft.com/en-US/json-schemas/rig-package/rig.schema.json",
-  "rigPackageName": "@organon/organon-node-rig"
+  "rigPackageName": "@organon/organon-node-rig",
+  "rigProfile": "commonjs-only"
 }

--- a/tooling/conventional-changelog/package.json
+++ b/tooling/conventional-changelog/package.json
@@ -10,14 +10,11 @@
   ],
   "license": "MIT",
   "type": "commonjs",
-  "main": "cjs/index.js",
-  "module": "lib/index.js",
+  "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!lib/**/__tests__",
-    "cjs",
-    "!cjs/**/__tests__"
+    "!lib/**/__tests__"
   ],
   "author": {
     "name": "Jason Lenoble",

--- a/tooling/conventional-changelog/package.json
+++ b/tooling/conventional-changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-organon",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A wrapper to use emojis with conventional-changelog and commitlint",
   "keywords": [
     "commitlint",

--- a/tooling/conventional-changelog/package.json
+++ b/tooling/conventional-changelog/package.json
@@ -15,9 +15,9 @@
   "types": "lib/index.d.ts",
   "files": [
     "lib",
-    "!lib/**/*.map",
+    "!lib/**/__tests__",
     "cjs",
-    "!cjs/**/*.map"
+    "!cjs/**/__tests__"
   ],
   "author": {
     "name": "Jason Lenoble",

--- a/tooling/conventional-changelog/src/__tests__/index.test.ts
+++ b/tooling/conventional-changelog/src/__tests__/index.test.ts
@@ -25,23 +25,23 @@ describe("conventional-changelog-organon", () => {
         expect(headerPattern.test(commitHeader)).toBe(true);
       });
 
-      it(`header "${type}(Scope): description" is invalid`, () => {
+      it(`header "${type}(Scope): description" is valid`, () => {
         const commitHeader = type + "(Scope): description";
 
-        expect(headerPattern.test(commitHeader)).toBe(false);
+        expect(headerPattern.test(commitHeader)).toBe(true);
       });
 
-      it(`header "${type}(scope): Description" is invalid`, () => {
-        const commitHeader = type + "(scope): Description";
+      it(`header "${type}(scope): Long description" is valid`, () => {
+        const commitHeader = type + "(scope): Long description";
 
-        expect(headerPattern.test(commitHeader)).toBe(false);
+        expect(headerPattern.test(commitHeader)).toBe(true);
       });
     });
 
     it(`header pattern exactly checks for all emojis in the emoji presentation map`, () => {
       const emojis = Array.from(emojiPresentationMap.values()).join("");
 
-      let truncatedSource: string = headerPattern.source.substring(10);
+      let truncatedSource: string = headerPattern.source.substring(3);
       truncatedSource = truncatedSource.substring(0, truncatedSource.indexOf("]"));
       truncatedSource = truncatedSource.replace(/.\\ufe0f/g, (match: string): string => {
         return emojiPresentationMap.get(match[0]) || "";

--- a/tooling/conventional-changelog/src/index.ts
+++ b/tooling/conventional-changelog/src/index.ts
@@ -14,7 +14,7 @@ interface IPresetOptions {
 // is kept loose for <commitType>, so there could be emojis anywhere.
 // \ufe0f is the emoji presentation character switch, we do require it in the pattern
 const headerPattern: RegExp = // eslint-disable-next-line no-misleading-character-class
-  /^([ a-z0-9👷💚📝✨🐛⚡♻\ufe0f⏪🎨✅]*)(?:\(([a-z0-9]*)\))?!?: ([a-z0-9]*)$/u;
+  /^([👷💚📝✨🐛⚡♻\ufe0f⏪🎨✅]{1,2} [a-z]+)(?:\((.*)\))?!?: (.*)$/u;
 
 // This replaces the header pattern to be fed to the conventional changelog parser
 // and allows for emojis in the header type

--- a/tooling/conventional-changelog/src/index.ts
+++ b/tooling/conventional-changelog/src/index.ts
@@ -13,12 +13,12 @@ interface IPresetOptions {
 // headerPattern is <commitType>(<commitScope>): <commitHeaderMessage>. The matching
 // is kept loose for <commitType>, so there could be emojis anywhere.
 // \ufe0f is the emoji presentation character switch, we do require it in the pattern
-export const headerPattern: RegExp = // eslint-disable-next-line no-misleading-character-class
+const headerPattern: RegExp = // eslint-disable-next-line no-misleading-character-class
   /^([ a-z0-9👷💚📝✨🐛⚡♻\ufe0f⏪🎨✅]*)(?:\(([a-z0-9]*)\))?!?: ([a-z0-9]*)$/u;
 
 // This replaces the header pattern to be fed to the conventional changelog parser
 // and allows for emojis in the header type
-export default async (parameter: (_: unknown, arg: IPresetOptions) => void): Promise<IPresetOptions> => {
+const exportFunc = async (parameter: (_: unknown, arg: IPresetOptions) => void): Promise<IPresetOptions> => {
   const loaded: IPresetOptions = await new Promise((resolve) => {
     // @ts-ignore
     getPresetOptions((any, arg: IPresetOptions) => {
@@ -33,3 +33,7 @@ export default async (parameter: (_: unknown, arg: IPresetOptions) => void): Pro
 
   return loaded;
 };
+
+exportFunc.headerPattern = headerPattern;
+
+export = exportFunc;

--- a/tooling/conventional-changelog/tsconfig.json
+++ b/tooling/conventional-changelog/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "./node_modules/@organon/organon-node-rig/profiles/default/tsconfig-base.json"
+  "extends": "./node_modules/@organon/organon-node-rig/profiles/commonjs-only/tsconfig-base.json"
 }


### PR DESCRIPTION
The package before being integrated into rushstack was a pure commonjs module.
The default build process overrides that and makes it incompatible with conventional-changelog.

So a new rig profile is created to handle pure commonjs modules.

Moreover the character casing enforced in pattern is dropped, as this is checked through rules by commitlint, which is
more explicit (so more informative messages on fail).